### PR TITLE
Prevent malformed UTF-8 characters in debug mode generating JS error

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -724,7 +724,13 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function showDebugger(array $output)
     {
-        $output['queries'] = $this->connection->getQueryLog();
+	    $query_log = $this->connection->getQueryLog();
+	    array_walk_recursive($query_log, function (&$item, $key)
+	    {
+		    $item = utf8_encode($item);
+	    });
+
+        $output['queries'] = $query_log;
         $output['input']   = $this->request->all();
 
         return $output;


### PR DESCRIPTION
To prevent UTF-8 error messages in debug mode when queries contain binary data, all texts in the queries part are processed with utf8_encode before adding in to the output.

In response to https://github.com/yajra/laravel-datatables/issues/1793